### PR TITLE
[Feature] 그룹 카트 - 수량 카운터 구현

### DIFF
--- a/core/ui/src/main/java/com/cyberwarriers/zubzub/core/ui/components/ZubZubNumberInputField.kt
+++ b/core/ui/src/main/java/com/cyberwarriers/zubzub/core/ui/components/ZubZubNumberInputField.kt
@@ -1,0 +1,138 @@
+package com.cyberwarriers.zubzub.core.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cyberwarriers.zubzub.core.ui.theme.ZubZubTheme
+
+/**
+ * 숫자 입력 전용 텍스트 필드 컴포넌트
+ */
+@Composable
+fun ZubZubNumberInputField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    placeholder: String = "",
+    isError: Boolean = false,
+    errorMessage: String = "",
+    enabled: Boolean = true,
+    allowZero: Boolean = false,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        // 상단 레이블
+        Text(
+            text = label,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        
+        // 숫자 입력 텍스트 필드
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight(),
+            value = value,
+            onValueChange = { newValue ->
+                // 숫자만 입력 가능하도록 필터링
+                if (newValue.isEmpty()) {
+                    onValueChange(newValue)
+                } else if (newValue.all { it.isDigit() }) {
+                    val number = newValue.toIntOrNull()
+                    if (number != null && (allowZero || number > 0)) {
+                        onValueChange(newValue)
+                    }
+                }
+            },
+            placeholder = {
+                if (placeholder.isNotEmpty()) {
+                    Text(
+                        text = placeholder,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            },
+            enabled = enabled,
+            singleLine = true,
+            isError = isError,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = Color.White,
+                unfocusedContainerColor = Color(0xFFE0E0E0),
+                errorContainerColor = Color(0xFFFFF5F5),
+                disabledContainerColor = Color(0xFFE0E0E0),
+                focusedBorderColor = Color.Black,
+                unfocusedBorderColor = Color.Transparent,
+                errorBorderColor = MaterialTheme.colorScheme.error,
+                disabledBorderColor = Color.Transparent,
+                focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                disabledTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+            )
+        )
+        
+        // 에러 메시지
+        if (isError && errorMessage.isNotEmpty()) {
+            Text(
+                text = errorMessage,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ZubZubNumberInputFieldPreview() {
+    ZubZubTheme {
+        Column(
+            modifier = Modifier.padding(20.dp)
+        ) {
+            ZubZubNumberInputField(
+                value = "5000",
+                onValueChange = {},
+                label = "가격",
+                placeholder = "가격을 입력하세요 (원)"
+            )
+            
+            ZubZubNumberInputField(
+                value = "2",
+                onValueChange = {},
+                label = "수량",
+                placeholder = "수량",
+                modifier = Modifier.padding(top = 16.dp)
+            )
+            
+            ZubZubNumberInputField(
+                value = "",
+                onValueChange = {},
+                label = "에러 상태",
+                placeholder = "필수 입력 항목",
+                isError = true,
+                errorMessage = "수량은 1 이상이어야 합니다.",
+                modifier = Modifier.padding(top = 16.dp)
+            )
+        }
+    }
+} 

--- a/feature/group-cart/build.gradle.kts
+++ b/feature/group-cart/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
     androidTestImplementation(platform(libs.androidx.compose.bom))
 
     // ViewModel

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/data/datasource/GroupCartDataSource.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/data/datasource/GroupCartDataSource.kt
@@ -1,6 +1,7 @@
 package com.cyberwarriers.zubzub.feature.group_cart.data.datasource
 
 import com.cyberwarriers.zubzub.core.util.logd
+import com.cyberwarriers.zubzub.feature.group_cart.data.model.CartItemEntity
 import com.cyberwarriers.zubzub.feature.group_cart.data.model.GroupCartDetailEntity
 import com.cyberwarriers.zubzub.feature.group_cart.data.model.GroupMemberEntity
 import com.google.firebase.firestore.FirebaseFirestore
@@ -31,6 +32,32 @@ class GroupCartDataSource @Inject constructor(
         logd("Firebase 그룹 조회 시작 - 그룹 ID: $groupId")
         val groupRef = firestore.collection(GROUPS_COLLECTION).document(groupId)
         
+        // 그룹 정보와 카트 아이템을 동시에 관찰하기 위한 변수들
+        var currentGroupData: Map<String, Any>? = null
+        var currentCartItems: List<CartItemEntity> = emptyList()
+        var currentMembers: List<GroupMemberEntity> = emptyList()
+        
+        // 데이터 조합 및 전송 함수
+        fun combineAndSendData() {
+            currentGroupData?.let { groupData ->
+                val groupName = groupData["groupName"] as? String ?: ""
+                val memberIds = groupData["memberIds"] as? List<String> ?: emptyList()
+                val memberCount = memberIds.size
+                
+                val groupCartDetail = GroupCartDetailEntity(
+                    groupId = groupId,
+                    groupName = groupName,
+                    memberCount = memberCount,
+                    cartItems = currentCartItems,
+                    members = currentMembers
+                )
+                
+                logd("데이터 조합 완료 - 그룹: '$groupName', 아이템: ${currentCartItems.size}개, 멤버: ${currentMembers.size}명")
+                trySend(groupCartDetail)
+            }
+        }
+        
+        // 1. 그룹 정보 리스너
         val groupListener = groupRef.addSnapshotListener { groupSnapshot, error ->
             if (error != null) {
                 logd("Firebase 그룹 조회 에러: ${error.message}")
@@ -40,47 +67,26 @@ class GroupCartDataSource @Inject constructor(
             
             if (groupSnapshot?.exists() == true) {
                 logd("Firebase 그룹 문서 발견")
-                logd("전체 문서 데이터: ${groupSnapshot.data}")
+                currentGroupData = groupSnapshot.data
                 
-                // 모든 필드를 로그로 출력해서 구조 파악
-                groupSnapshot.data?.forEach { (key, value) ->
-                    logd("필드: $key = $value (타입: ${value?.javaClass?.simpleName})")
-                }
-                
-                // 그룹 기본 정보 추출
                 val groupName = groupSnapshot.getString("groupName") ?: ""
                 val memberIds = groupSnapshot.get("memberIds") as? List<String> ?: emptyList()
-                val memberCount = memberIds.size
                 
-                logd("추출된 그룹 정보 - 이름: '$groupName', 멤버 ID들: $memberIds, 멤버수: $memberCount")
+                logd("그룹 정보 업데이트 - 이름: '$groupName', 멤버 ID들: $memberIds")
                 
-                // memberIds가 있으면 users 컬렉션에서 실제 사용자 정보 조회
+                // 멤버 정보 조회
                 if (memberIds.isNotEmpty()) {
-                    logd("사용자 정보 조회 시작 - ${memberIds.size}명")
-                    logd("조회할 memberIds: $memberIds")
-                    
-                    // whereIn으로 한번에 모든 사용자 조회 (효율적인 방식)
                     firestore.collection("users")
                         .whereIn("userId", memberIds)
                         .addSnapshotListener { usersSnapshot, usersError ->
                             if (usersError != null) {
                                 logd("사용자 정보 조회 에러: ${usersError.message}")
-                                // 에러가 있어도 그룹 정보는 표시 (빈 멤버 리스트)
-                                val groupCartDetail = GroupCartDetailEntity(
-                                    groupId = groupId,
-                                    groupName = groupName,
-                                    memberCount = memberCount,
-                                    cartItems = emptyList(),
-                                    members = emptyList()
-                                )
-                                trySend(groupCartDetail)
+                                currentMembers = emptyList()
+                                combineAndSendData()
                                 return@addSnapshotListener
                             }
                             
-                            logd("사용자 정보 조회 결과: ${usersSnapshot?.documents?.size ?: 0}명")
-                            
-                            val members = usersSnapshot?.documents?.mapNotNull { userDoc ->
-                                logd("사용자 데이터: ${userDoc.data}")
+                            currentMembers = usersSnapshot?.documents?.mapNotNull { userDoc ->
                                 try {
                                     GroupMemberEntity(
                                         id = userDoc.getString("userId") ?: userDoc.id,
@@ -98,34 +104,12 @@ class GroupCartDataSource @Inject constructor(
                                 }
                             }?.sortedWith(compareBy<GroupMemberEntity> { !it.isGroupLeader }.thenBy { it.joinedAt }) ?: emptyList()
                             
-                            logd("파싱된 멤버 정보: ${members.size}명")
-                            members.forEach { member ->
-                                logd("멤버: ${member.name} (${member.email}), 리더: ${member.isGroupLeader}, 입장일: ${java.text.SimpleDateFormat("MM-dd HH:mm", java.util.Locale.getDefault()).format(java.util.Date(member.joinedAt))}")
-                            }
-                            
-                            // 전체 데이터 조합
-                            val groupCartDetail = GroupCartDetailEntity(
-                                groupId = groupId,
-                                groupName = groupName,
-                                memberCount = memberCount,
-                                cartItems = emptyList(),
-                                members = members
-                            )
-                            
-                            logd("최종 데이터 조합 완료 - 그룹: '$groupName', 멤버: ${members.size}명")
-                            trySend(groupCartDetail)
+                            logd("멤버 정보 업데이트: ${currentMembers.size}명")
+                            combineAndSendData()
                         }
                 } else {
-                    logd("멤버 ID가 없음 - 빈 그룹")
-                    // memberIds가 없으면 빈 그룹으로 처리
-                    val groupCartDetail = GroupCartDetailEntity(
-                        groupId = groupId,
-                        groupName = groupName,
-                        memberCount = 0,
-                        cartItems = emptyList(),
-                        members = emptyList()
-                    )
-                    trySend(groupCartDetail)
+                    currentMembers = emptyList()
+                    combineAndSendData()
                 }
             } else {
                 logd("Firebase 그룹 문서가 존재하지 않음: $groupId")
@@ -133,9 +117,46 @@ class GroupCartDataSource @Inject constructor(
             }
         }
         
+        // 2. 카트 아이템 리스너
+        val cartItemsListener = groupRef.collection(CART_ITEMS_SUBCOLLECTION)
+            .orderBy("addedAt")
+            .addSnapshotListener { cartSnapshot, error ->
+                if (error != null) {
+                    logd("Firebase 카트 아이템 조회 에러: ${error.message}")
+                    currentCartItems = emptyList()
+                    combineAndSendData()
+                    return@addSnapshotListener
+                }
+                
+                currentCartItems = cartSnapshot?.documents?.mapNotNull { itemDoc ->
+                    try {
+                        CartItemEntity(
+                            id = itemDoc.id,
+                            name = itemDoc.getString("name") ?: "",
+                            price = itemDoc.getLong("price") ?: 0L,
+                            quantity = itemDoc.getLong("quantity")?.toInt() ?: 1,
+                            addedBy = itemDoc.getString("addedBy") ?: "익명",
+                            addedAt = itemDoc.getLong("addedAt") ?: 0L,
+                            isCompleted = itemDoc.getBoolean("isCompleted") ?: false
+                        )
+                    } catch (e: Exception) {
+                        logd("카트 아이템 파싱 에러: ${e.message}")
+                        null
+                    }
+                } ?: emptyList()
+                
+                logd("카트 아이템 업데이트: ${currentCartItems.size}개")
+                currentCartItems.forEach { item ->
+                    logd("아이템: ${item.name} - ${item.price}원 x ${item.quantity}개 (완료: ${item.isCompleted})")
+                }
+                
+                combineAndSendData()
+            }
+        
         awaitClose { 
             groupListener.remove()
-            logd("Firebase 그룹 리스너 해제: $groupId")
+            cartItemsListener.remove()
+            logd("Firebase 리스너 해제: $groupId")
         }
     }
 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/domain/usecase/AddCartItemUseCase.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/domain/usecase/AddCartItemUseCase.kt
@@ -1,0 +1,20 @@
+package com.cyberwarriers.zubzub.feature.group_cart.domain.usecase
+
+import com.cyberwarriers.zubzub.feature.group_cart.domain.repository.GroupCartRepository
+import javax.inject.Inject
+
+/**
+ * 카트 아이템 추가 UseCase
+ */
+class AddCartItemUseCase @Inject constructor(
+    private val repository: GroupCartRepository
+) {
+    suspend operator fun invoke(
+        groupId: String,
+        name: String,
+        price: Long,
+        quantity: Int
+    ): Result<String> {
+        return repository.addCartItem(groupId, name, price, quantity)
+    }
+} 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cyberwarriers.zubzub.core.util.logd
+import com.cyberwarriers.zubzub.feature.group_cart.domain.usecase.AddCartItemUseCase
 import com.cyberwarriers.zubzub.feature.group_cart.domain.usecase.GetGroupCartDetailUseCase
 import com.cyberwarriers.zubzub.feature.group_cart.domain.usecase.UpdateCartItemStatusUseCase
 import com.cyberwarriers.zubzub.feature.group_cart.presentation.effect.GroupCartEffect
@@ -29,7 +30,8 @@ import javax.inject.Inject
 class GroupCartViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getGroupCartDetailUseCase: GetGroupCartDetailUseCase,
-    private val updateCartItemStatusUseCase: UpdateCartItemStatusUseCase
+    private val updateCartItemStatusUseCase: UpdateCartItemStatusUseCase,
+    private val addCartItemUseCase: AddCartItemUseCase
 ) : ViewModel() {
 
     // UI 상태 관리
@@ -93,7 +95,7 @@ class GroupCartViewModel @Inject constructor(
     /**
      * Effect 발생
      */
-    fun emitEffect(effect: GroupCartEffect) {
+    private fun emitEffect(effect: GroupCartEffect) {
         viewModelScope.launch {
             _effect.emit(effect)
         }
@@ -155,9 +157,19 @@ class GroupCartViewModel @Inject constructor(
     }
 
     /**
-     * 새로고침
+     * 카트 아이템 추가
      */
-    fun onRefresh() {
-        loadGroupCartDetail()
+    fun onCartItemAdd(name: String, price: Int, quantity: Int) {
+        viewModelScope.launch {
+            addCartItemUseCase(groupId, name, price.toLong(), quantity)
+                .onSuccess { itemId ->
+                    logd("카트 아이템 추가 성공: $itemId")
+                    emitEffect(GroupCartEffect.ShowSuccess("아이템이 추가되었습니다"))
+                }
+                .onFailure { exception ->
+                    logd("카트 아이템 추가 실패: ${exception.message}")
+                    emitEffect(GroupCartEffect.ShowError("아이템 추가에 실패했습니다"))
+                }
+        }
     }
 } 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * 그룹 카트 화면 ViewModel (Clean Architecture 적용)
+ * 그룹 카트 화면 ViewModel
  */
 @HiltViewModel
 class GroupCartViewModel @Inject constructor(

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/effect/GroupCartEffect.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/effect/GroupCartEffect.kt
@@ -5,7 +5,6 @@ package com.cyberwarriers.zubzub.feature.group_cart.presentation.effect
  */
 sealed class GroupCartEffect {
     object NavigateBack : GroupCartEffect()
-    object NavigateToAddItem : GroupCartEffect()
     data class NavigateToMemberDetail(val memberId: String) : GroupCartEffect()
     object NavigateToGroupSettings : GroupCartEffect()
     data class ShowError(val message: String) : GroupCartEffect()

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/GroupCartScreen.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/GroupCartScreen.kt
@@ -40,10 +40,6 @@ fun GroupCartScreen(
                     onNavigateBack()
                 }
 
-                is GroupCartEffect.NavigateToAddItem -> {
-                    // TODO: 아이템 추가 화면으로 네비게이션
-                }
-
                 is GroupCartEffect.NavigateToMemberDetail -> {
                     // TODO: 멤버 상세 정보 화면으로 네비게이션
                 }

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/GroupCartScreen.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/GroupCartScreen.kt
@@ -100,7 +100,6 @@ fun GroupCartScreen(
                 TabItem.CART.index -> {
                     CartListContent(
                         cartItems = uiState.cartItems,
-                        onAddItem = { viewModel.emitEffect(GroupCartEffect.NavigateToAddItem) },
                         onItemToggle = { itemId ->
                             val item = uiState.cartItems.find { it.id == itemId }
                             item?.let {
@@ -109,6 +108,9 @@ fun GroupCartScreen(
                                     !it.isCompleted
                                 )
                             }
+                        },
+                        onCartItemAdd = { name, price, quantity ->
+                            viewModel.onCartItemAdd(name, price, quantity)
                         }
                     )
                 }

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/CartListContent.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/CartListContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -158,20 +159,18 @@ fun CartListContent(
  * 카트 아이템 추가 바텀시트
  */
 @Composable
-private fun AddCartItemBottomSheet(
+internal fun AddCartItemBottomSheet(
     onDismiss: () -> Unit,
     onAddItem: (name: String, price: Int, quantity: Int) -> Unit
 ) {
     var itemName by remember { mutableStateOf("") }
     var itemPrice by remember { mutableStateOf("") }
-    var itemQuantity by remember { mutableStateOf("1") }
+    var itemQuantity by remember { mutableIntStateOf(1) }
 
     val isFormValid = itemName.isNotBlank() &&
             itemPrice.isNotBlank() &&
             itemPrice.toIntOrNull() != null &&
-            itemQuantity.isNotBlank() &&
-            itemQuantity.toIntOrNull() != null &&
-            (itemQuantity.toIntOrNull() ?: 0) > 0
+            itemQuantity > 0
 
     Column(
         modifier = Modifier
@@ -180,51 +179,67 @@ private fun AddCartItemBottomSheet(
     ) {
         // 제목
         Text(
-            text = "아이템 추가",
+            text = "장바구니 추가",
             fontSize = 24.sp,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(vertical = 16.dp)
+            modifier = Modifier.padding(vertical = 24.dp)
         )
 
-        // 폼 필드들
+        // 폼 필드
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            // 아이템 이름
+            // 이름
             ZubZubInputTextField(
                 value = itemName,
                 onValueChange = { itemName = it },
-                label = "아이템 이름",
-                placeholder = "구매할 아이템 이름을 입력하세요"
+                label = "이름",
+                placeholder = "장바구니에 담을 이름을 입력하세요"
             )
 
-            // 가격
-            ZubZubNumberInputField(
-                value = itemPrice,
-                onValueChange = { itemPrice = it },
-                label = "가격",
-                placeholder = "가격을 입력하세요 (원)",
-                allowZero = false
-            )
 
-            // 수량
-            ZubZubNumberInputField(
-                value = itemQuantity,
-                onValueChange = { itemQuantity = it },
-                label = "수량",
-                placeholder = "수량",
-                allowZero = false
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                // 가격
+                ZubZubNumberInputField(
+                    value = itemPrice,
+                    onValueChange = { itemPrice = it },
+                    label = "가격",
+                    placeholder = "가격을 입력하세요",
+                    allowZero = false,
+                    modifier = Modifier.weight(1.2f)
+                )
+
+                // 수량
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = "수량",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(bottom = 4.dp)
+                    )
+                    
+                    QuantityCounter(
+                        quantity = itemQuantity,
+                        onQuantityChange = { itemQuantity = it }
+                    )
+                }
+            }
         }
+        Spacer(modifier = Modifier.height(36.dp))
 
         ZubZubSubmitButton(
             modifier = Modifier.padding(horizontal = 16.dp),
             text = "카트에 추가하기",
             onClick = {
                 val price = itemPrice.toIntOrNull() ?: 0
-                val quantity = itemQuantity.toIntOrNull() ?: 1
-                onAddItem(itemName, price, quantity)
+                onAddItem(itemName, price, itemQuantity)
             },
             enable = isFormValid,
         )
@@ -374,4 +389,16 @@ fun CartListContentEmptyPreview() {
             cartItems = emptyList()
         )
     }
-} 
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AddCartItemBottomSheetPreview() {
+    ZubZubTheme {
+        AddCartItemBottomSheet(
+            onDismiss = { },
+            onAddItem = { name, price, quantity ->
+            }
+        )
+    }
+}

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/CartListContent.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/CartListContent.kt
@@ -293,6 +293,12 @@ private fun CartItemCard(
                     )
                     Spacer(modifier = Modifier.size(8.dp))
                     Text(
+                        text = "수량 ${item.quantity}",
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text(
                         text = "by ${item.addedBy}",
                         fontSize = 12.sp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/CartListContent.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/CartListContent.kt
@@ -9,8 +9,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -21,12 +24,19 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -35,18 +45,27 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cyberwarriers.zubzub.core.ui.components.ZubZubInputTextField
+import com.cyberwarriers.zubzub.core.ui.components.ZubZubNumberInputField
+import com.cyberwarriers.zubzub.core.ui.components.ZubZubSubmitButton
 import com.cyberwarriers.zubzub.core.ui.theme.ZubZubTheme
 import com.cyberwarriers.zubzub.feature.group_cart.presentation.data.CartItem
 
 /**
  * 카트 목록 콘텐츠
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CartListContent(
     cartItems: List<CartItem> = emptyList(),
-    onAddItem: () -> Unit = {},
     onItemToggle: (String) -> Unit = {},
+    onCartItemAdd: (name: String, price: Int, quantity: Int) -> Unit = { _, _, _ -> },
 ) {
+    var showBottomSheet by remember { mutableStateOf(false) }
+    val bottomSheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -97,7 +116,9 @@ fun CartListContent(
 
         // 플로팅 액션 버튼
         FloatingActionButton(
-            onClick = onAddItem,
+            onClick = {
+                showBottomSheet = true
+            },
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp),
@@ -110,6 +131,106 @@ fun CartListContent(
             )
         }
     }
+
+    // 바텀시트
+    if (showBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showBottomSheet = false },
+            sheetState = bottomSheetState,
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .safeContentPadding()
+                .padding(top = 8.dp)
+        ) {
+            AddCartItemBottomSheet(
+                onDismiss = { showBottomSheet = false },
+                onAddItem = { name, price, quantity ->
+                    onCartItemAdd(name, price, quantity)
+                    showBottomSheet = false
+                }
+            )
+        }
+    }
+}
+
+/**
+ * 카트 아이템 추가 바텀시트
+ */
+@Composable
+private fun AddCartItemBottomSheet(
+    onDismiss: () -> Unit,
+    onAddItem: (name: String, price: Int, quantity: Int) -> Unit
+) {
+    var itemName by remember { mutableStateOf("") }
+    var itemPrice by remember { mutableStateOf("") }
+    var itemQuantity by remember { mutableStateOf("1") }
+
+    val isFormValid = itemName.isNotBlank() &&
+            itemPrice.isNotBlank() &&
+            itemPrice.toIntOrNull() != null &&
+            itemQuantity.isNotBlank() &&
+            itemQuantity.toIntOrNull() != null &&
+            (itemQuantity.toIntOrNull() ?: 0) > 0
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+    ) {
+        // 제목
+        Text(
+            text = "아이템 추가",
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(vertical = 16.dp)
+        )
+
+        // 폼 필드들
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // 아이템 이름
+            ZubZubInputTextField(
+                value = itemName,
+                onValueChange = { itemName = it },
+                label = "아이템 이름",
+                placeholder = "구매할 아이템 이름을 입력하세요"
+            )
+
+            // 가격
+            ZubZubNumberInputField(
+                value = itemPrice,
+                onValueChange = { itemPrice = it },
+                label = "가격",
+                placeholder = "가격을 입력하세요 (원)",
+                allowZero = false
+            )
+
+            // 수량
+            ZubZubNumberInputField(
+                value = itemQuantity,
+                onValueChange = { itemQuantity = it },
+                label = "수량",
+                placeholder = "수량",
+                allowZero = false
+            )
+        }
+
+        ZubZubSubmitButton(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            text = "카트에 추가하기",
+            onClick = {
+                val price = itemPrice.toIntOrNull() ?: 0
+                val quantity = itemQuantity.toIntOrNull() ?: 1
+                onAddItem(itemName, price, quantity)
+            },
+            enable = isFormValid,
+        )
+        Spacer(modifier = Modifier.height(36.dp))
+    }
+
 }
 
 @Composable

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/QuantityCounter.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/QuantityCounter.kt
@@ -1,0 +1,135 @@
+package com.cyberwarriers.zubzub.feature.group_cart.presentation.ui.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+
+/**
+ * 수량 카운터 컴포넌트
+ * 클릭 가능한 수량 조절 컴포넌트
+ */
+@Composable
+fun QuantityCounter(
+    quantity: Int,
+    onQuantityChange: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val minQuantity = 1
+    val maxQuantity = 99
+    val minusInteractionSource = remember { MutableInteractionSource() }
+    val plusInteractionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier
+            .height(56.dp)
+            .border(
+                width = 2.dp,
+                color = Color.Black,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(horizontal = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // 마이너스 버튼
+            Icon(
+                imageVector = Icons.Default.Remove,
+                contentDescription = "수량 감소",
+                tint = if (quantity > minQuantity) {
+                    Color.Black
+                } else {
+                    Color.LightGray
+                },
+                modifier = Modifier
+                    .size(32.dp)
+                    .clickable(
+                        interactionSource = minusInteractionSource,
+                        indication = null
+                    ) {
+                        if (quantity > minQuantity) {
+                            onQuantityChange(quantity - 1)
+                        }
+                    }
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // 숫자 영역 고정 너비
+            Box(
+                modifier = Modifier.width(32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = quantity.toString(),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.Black
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // 플러스 버튼
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "수량 증가",
+                tint = if (quantity < maxQuantity) {
+                    Color.Black
+                } else {
+                    Color.LightGray
+                },
+                modifier = Modifier
+                    .size(32.dp)
+                    .clickable(
+                        interactionSource = plusInteractionSource,
+                        indication = null
+                    ) {
+                        if (quantity < maxQuantity) {
+                            onQuantityChange(quantity + 1)
+                        }
+                    }
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun QuantityCounterPreview() {
+    MaterialTheme {
+        QuantityCounter(
+            quantity = 3,
+            onQuantityChange = {}
+        )
+    }
+}

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/utils/EffectUtils.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/utils/EffectUtils.kt
@@ -9,13 +9,6 @@ import kotlinx.coroutines.launch
  * Effect 발생을 위한 공통 유틸리티
  */
 object EffectUtils {
-    
-    /**
-     * Effect를 발생시키는 확장 함수
-     * 
-     * @param effect 발생시킬 Effect
-     * @param effectFlow Effect를 전송할 SharedFlow
-     */
     fun <T> ViewModel.emitEffect(
         effect: T,
         effectFlow: MutableSharedFlow<T>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
# 그룹 카트 추가 기능

## 개요
장바구니 추가 기능에 수량 카운터 컴포넌트를 구현하고,  
아이템에 수량 정보를 표시하는 기능을 추가했습니다.

## 주요 변경사항

### 1. QuantityCounter 컴포넌트 구현
- 클릭 가능한 수량 조절 컴포넌트
- 테두리 디자인: 검은색 2dp, 4dp 코너
- 고정 높이 56dp, 수직 가운데 정렬
- 최소값 1, 최대값 99 제한
- Surface 제거로 깔끔한 아이콘 버튼


