### PR TITLE
[Feature] 장바구니 아이템 체크에 따른 진행률 업데이트 기능 구현

### DIFF
--- a/core/data/src/main/java/com/cyberwarriers/zubzub/core/data/mapper/CartGroupMapper.kt
+++ b/core/data/src/main/java/com/cyberwarriers/zubzub/core/data/mapper/CartGroupMapper.kt
@@ -15,15 +15,11 @@ import com.cyberwarriers.zubzub.core.domain.model.MemberRole
 
 // Firebase Entity -> CartGroupSummary
 fun CartGroupFirebaseEntity.toSummary(currentUserId: String): CartGroupSummary {
-    val progressPercentage = if (targetAmount > 0) {
-        ((currentAmount.toDouble() / targetAmount.toDouble()) * 100).toInt()
-    } else 0
-    
     return CartGroupSummary(
         groupId = groupId,
         groupName = groupName,
         memberCount = memberIds.size,
-        progressPercentage = progressPercentage,
+        progressPercentage = progressPercentage.coerceIn(0, 100),
         createdAt = createdAt?.seconds?.times(1000) ?: System.currentTimeMillis(),
         isOwner = createdBy == currentUserId,
         currentAmount = currentAmount,
@@ -33,10 +29,6 @@ fun CartGroupFirebaseEntity.toSummary(currentUserId: String): CartGroupSummary {
 
 // Firebase Entity -> CartGroupDetail (멤버 리스트 필요)
 fun CartGroupFirebaseEntity.toDetail(members: List<GroupMember>): CartGroupDetail {
-    val progressPercentage = if (targetAmount > 0) {
-        ((currentAmount.toDouble() / targetAmount.toDouble()) * 100).toInt()
-    } else 0
-    
     return CartGroupDetail(
         groupId = groupId,
         groupName = groupName,
@@ -44,7 +36,7 @@ fun CartGroupFirebaseEntity.toDetail(members: List<GroupMember>): CartGroupDetai
         members = members,
         totalAmount = currentAmount,
         targetAmount = targetAmount,
-        progressPercentage = progressPercentage,
+        progressPercentage = progressPercentage.coerceIn(0, 100), // Firebase에서 직접 가져오기
         createdAt = createdAt?.seconds?.times(1000) ?: System.currentTimeMillis(),
         updatedAt = updatedAt?.seconds?.times(1000) ?: System.currentTimeMillis(),
         settings = settings.toGroupSettings(),

--- a/core/data/src/main/java/com/cyberwarriers/zubzub/core/data/model/CartGroupFirebaseEntity.kt
+++ b/core/data/src/main/java/com/cyberwarriers/zubzub/core/data/model/CartGroupFirebaseEntity.kt
@@ -24,6 +24,7 @@ data class CartGroupFirebaseEntity(
     val status: String = "ACTIVE", // ACTIVE, COMPLETED, INACTIVE
     val targetAmount: Long = 0L,
     val currentAmount: Long = 0L,
+    val progressPercentage: Int = 0,
     
     // 설정 정보
     val settings: Map<String, Any> = mapOf(

--- a/core/data/src/main/java/com/cyberwarriers/zubzub/core/data/repository/CartGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/com/cyberwarriers/zubzub/core/data/repository/CartGroupRepositoryImpl.kt
@@ -108,50 +108,22 @@ class CartGroupRepositoryImpl @Inject constructor(
                 if (snapshot != null) {
                     val groups = snapshot.documents.mapNotNull { document ->
                         try {
-                            document.toObject(CartGroupFirebaseEntity::class.java)
+                            val entity = document.toObject(CartGroupFirebaseEntity::class.java)
                                 ?.copy(groupId = document.id)
-                                ?.toSummary(userId)
+                            
+                            entity?.toSummary(userId)
                         } catch (e: Exception) {
                             logd("그룹 변환 실패: ${e.message}")
                             null
                         }
                     }
-                    
-                    logd("실시간 그룹 업데이트: ${groups.size}개")
                     trySend(groups)
                 }
             }
         
-        // 리스너 정리 (Flow 종료시 자동 호출)
         awaitClose {
-            logd("🧹 실시간 그룹 목록 리스너 해제")
+            logd("실시간 그룹 목록 리스너 해제")
             listener.remove()
-        }
-    }
-
-    /**
-     * 특정 그룹 상세 정보 조회
-     */
-    suspend fun getGroupDetail(groupId: String): Result<CartGroupFirebaseEntity?> {
-        return try {
-            logd("그룹 상세 조회: $groupId")
-            
-            val snapshot = firestore.collection(CART_GROUPS_COLLECTION)
-                .document(groupId)
-                .get()
-                .await()
-            
-            if (snapshot.exists()) {
-                val group = snapshot.toObject(CartGroupFirebaseEntity::class.java)
-                    ?.copy(groupId = snapshot.id)
-                Result.success(group)
-            } else {
-                Result.success(null)
-            }
-            
-        } catch (e: Exception) {
-            logd("그룹 상세 조회 실패: ${e.message}")
-            Result.failure(e)
         }
     }
 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/data/datasource/GroupCartDataSource.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/data/datasource/GroupCartDataSource.kt
@@ -165,14 +165,20 @@ class GroupCartDataSource @Inject constructor(
      */
     suspend fun updateCartItemStatus(groupId: String, itemId: String, isCompleted: Boolean): Boolean {
         return try {
+            // 1. 카트 아이템 상태 업데이트
             firestore.collection(GROUPS_COLLECTION)
                 .document(groupId)
                 .collection(CART_ITEMS_SUBCOLLECTION)
                 .document(itemId)
                 .update("isCompleted", isCompleted)
                 .await()
+            
+            // 2. 그룹 진행률 업데이트
+            updateGroupProgress(groupId)
+            
             true
         } catch (e: Exception) {
+            logd("카트 아이템 상태 업데이트 실패: ${e.message}")
             false
         }
     }
@@ -203,8 +209,12 @@ class GroupCartDataSource @Inject constructor(
                 .add(cartItemData)
                 .await()
             
+            // 진행률 업데이트 (새 아이템이 추가되어 전체 아이템 수가 변경됨)
+            updateGroupProgress(groupId)
+            
             docRef.id
         } catch (e: Exception) {
+            logd("카트 아이템 추가 실패: ${e.message}")
             null
         }
     }
@@ -220,9 +230,70 @@ class GroupCartDataSource @Inject constructor(
                 .document(itemId)
                 .delete()
                 .await()
+            
+            // 진행률 업데이트 (아이템이 삭제되어 전체 아이템 수가 변경됨)
+            updateGroupProgress(groupId)
+            
             true
         } catch (e: Exception) {
+            logd("카트 아이템 삭제 실패: ${e.message}")
             false
+        }
+    }
+    
+    /**
+     * 그룹 진행률 업데이트 (공통 함수)
+     */
+    private suspend fun updateGroupProgress(groupId: String) {
+        try {
+            // 전체 카트 아이템을 조회하여 진행률 계산
+            val cartItemsSnapshot = firestore.collection(GROUPS_COLLECTION)
+                .document(groupId)
+                .collection(CART_ITEMS_SUBCOLLECTION)
+                .get()
+                .await()
+            
+            val cartItems = cartItemsSnapshot.documents.mapNotNull { itemDoc ->
+                try {
+                    CartItemEntity(
+                        id = itemDoc.id,
+                        name = itemDoc.getString("name") ?: "",
+                        price = itemDoc.getLong("price") ?: 0L,
+                        quantity = itemDoc.getLong("quantity")?.toInt() ?: 1,
+                        addedBy = itemDoc.getString("addedBy") ?: "익명",
+                        addedAt = itemDoc.getLong("addedAt") ?: 0L,
+                        isCompleted = itemDoc.getBoolean("isCompleted") ?: false
+                    )
+                } catch (e: Exception) {
+                    logd("카트 아이템 파싱 에러: ${e.message}")
+                    null
+                }
+            }
+            
+            val progressPercentage = if (cartItems.isNotEmpty()) {
+                val completedItems = cartItems.count { it.isCompleted }
+                val calculatedProgress = ((completedItems.toDouble() / cartItems.size) * 100).toInt()
+                calculatedProgress.coerceIn(0, 100) // 0-100 범위로 제한
+            } else {
+                0
+            }
+            
+            logd("그룹 진행률 업데이트: ${cartItems.count { it.isCompleted }}개 완료 / ${cartItems.size}개 전체 = ${progressPercentage}%")
+            
+            // 그룹 문서의 진행률과 updatedAt 업데이트 (실시간 리스너 트리거)
+            firestore.collection(GROUPS_COLLECTION)
+                .document(groupId)
+                .update(
+                    mapOf(
+                        "progressPercentage" to progressPercentage,
+                        "updatedAt" to com.google.firebase.Timestamp.now()
+                    )
+                )
+                .await()
+            
+            logd("Firebase 진행률 업데이트 완료: ${progressPercentage}%")
+        } catch (e: Exception) {
+            logd("그룹 진행률 업데이트 실패: ${e.message}")
         }
     }
 } 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
@@ -7,6 +7,7 @@ import com.cyberwarriers.zubzub.core.util.logd
 import com.cyberwarriers.zubzub.feature.group_cart.domain.usecase.AddCartItemUseCase
 import com.cyberwarriers.zubzub.feature.group_cart.domain.usecase.GetGroupCartDetailUseCase
 import com.cyberwarriers.zubzub.feature.group_cart.domain.usecase.UpdateCartItemStatusUseCase
+import com.cyberwarriers.zubzub.feature.group_cart.presentation.data.CartItem
 import com.cyberwarriers.zubzub.feature.group_cart.presentation.effect.GroupCartEffect
 import com.cyberwarriers.zubzub.feature.group_cart.presentation.mapper.toPresentation
 import com.cyberwarriers.zubzub.feature.group_cart.presentation.state.GroupCartUiState
@@ -31,7 +32,7 @@ class GroupCartViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getGroupCartDetailUseCase: GetGroupCartDetailUseCase,
     private val updateCartItemStatusUseCase: UpdateCartItemStatusUseCase,
-    private val addCartItemUseCase: AddCartItemUseCase
+    private val addCartItemUseCase: AddCartItemUseCase,
 ) : ViewModel() {
 
     // UI 상태 관리
@@ -47,6 +48,16 @@ class GroupCartViewModel @Inject constructor(
 
     init {
         loadGroupCartDetail()
+    }
+
+    /**
+     * 진행률 계산
+     */
+    private fun calculateProgress(cartItems: List<CartItem>): Float {
+        if (cartItems.isEmpty()) return 0f
+
+        val completedItems = cartItems.count { it.isCompleted }
+        return completedItems.toFloat() / cartItems.size
     }
 
     /**
@@ -72,12 +83,16 @@ class GroupCartViewModel @Inject constructor(
                 .collect { groupCartDetail ->
                     logd("그룹 카트 데이터 로드 성공: ${groupCartDetail.groupName}")
                     
+                    val cartItems = groupCartDetail.cartItems.map { it.toPresentation() }
+                    val progress = calculateProgress(cartItems)
+                    
                     _uiState.update { currentState ->
                         currentState.copy(
                             groupName = groupCartDetail.groupName,
                             memberCount = groupCartDetail.memberCount,
-                            cartItems = groupCartDetail.cartItems.map { it.toPresentation() },
+                            cartItems = cartItems,
                             members = groupCartDetail.members.map { it.toPresentation() },
+                            progress = progress,
                             isLoading = false
                         )
                     }
@@ -118,14 +133,18 @@ class GroupCartViewModel @Inject constructor(
         viewModelScope.launch {
             // 낙관적 업데이트 (UI 먼저 변경)
             _uiState.update { currentState ->
-                currentState.copy(
-                    cartItems = currentState.cartItems.map { item ->
-                        if (item.id == itemId) {
-                            item.copy(isCompleted = isCompleted)
-                        } else {
-                            item
-                        }
+                val updatedCartItems = currentState.cartItems.map { item ->
+                    if (item.id == itemId) {
+                        item.copy(isCompleted = isCompleted)
+                    } else {
+                        item
                     }
+                }
+                val progress = calculateProgress(updatedCartItems)
+                
+                currentState.copy(
+                    cartItems = updatedCartItems,
+                    progress = progress
                 )
             }
 
@@ -140,14 +159,18 @@ class GroupCartViewModel @Inject constructor(
                     
                     // 실패 시 원래 상태로 되돌리기
                     _uiState.update { currentState ->
-                        currentState.copy(
-                            cartItems = currentState.cartItems.map { item ->
-                                if (item.id == itemId) {
-                                    item.copy(isCompleted = !isCompleted)
-                                } else {
-                                    item
-                                }
+                        val revertedCartItems = currentState.cartItems.map { item ->
+                            if (item.id == itemId) {
+                                item.copy(isCompleted = !isCompleted)
+                            } else {
+                                item
                             }
+                        }
+                        val progress = calculateProgress(revertedCartItems)
+                        
+                        currentState.copy(
+                            cartItems = revertedCartItems,
+                            progress = progress
                         )
                     }
                     

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/GroupCartViewModel.kt
@@ -51,13 +51,19 @@ class GroupCartViewModel @Inject constructor(
     }
 
     /**
-     * 진행률 계산
+     * 진행률 계산 (완료된 아이템 수 / 전체 아이템 수)
+     * @param cartItems 카트 아이템 리스트
+     * @return 진행률 (0.0 ~ 1.0)
      */
     private fun calculateProgress(cartItems: List<CartItem>): Float {
         if (cartItems.isEmpty()) return 0f
 
         val completedItems = cartItems.count { it.isCompleted }
-        return completedItems.toFloat() / cartItems.size
+        val progress = completedItems.toFloat() / cartItems.size
+        
+        logd("진행률 계산: ${completedItems}개 완료 / ${cartItems.size}개 전체 = ${(progress * 100).toInt()}%")
+        
+        return progress
     }
 
     /**

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/state/GroupCartUiState.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/state/GroupCartUiState.kt
@@ -12,5 +12,6 @@ data class GroupCartUiState(
     val members: List<Member> = emptyList(),
     val groupName: String = "",
     val memberCount: Int = 0,
-    val isLoading: Boolean = false
+    val progress: Float = 0f,
+    val isLoading: Boolean = false,
 ) 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/GroupCartScreen.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/GroupCartScreen.kt
@@ -82,7 +82,8 @@ fun GroupCartScreen(
             // 그룹 카트 헤더
             GroupCartHeader(
                 groupName = uiState.groupName,
-                memberCount = uiState.memberCount
+                memberCount = uiState.memberCount,
+                progress = uiState.progress
             )
 
             // 탭 레이아웃

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/GroupCartHeader.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/GroupCartHeader.kt
@@ -65,15 +65,4 @@ fun GroupCartHeaderPreview() {
             progress = 0.6f
         )
     }
-}
-
-@Preview
-@Composable
-fun ProgressBarPreview() {
-    ZubZubTheme {
-        ProgressBar(
-            progress = 0.75f,
-            modifier = Modifier.padding(16.dp)
-        )
-    }
 } 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/GroupCartHeader.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/GroupCartHeader.kt
@@ -22,6 +22,7 @@ import com.cyberwarriers.zubzub.core.ui.theme.ZubZubTheme
 fun GroupCartHeader(
     groupName: String,
     memberCount: Int,
+    progress: Float = 0f,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -44,6 +45,12 @@ fun GroupCartHeader(
             fontSize = 12.sp,
         )
 
+        // 진행률 바
+        ProgressBar(
+            progress = progress,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+
         Spacer(modifier = Modifier.size(12.dp))
     }
 }
@@ -54,7 +61,19 @@ fun GroupCartHeaderPreview() {
     ZubZubTheme {
         GroupCartHeader(
             groupName = "우리 가족",
-            memberCount = 4
+            memberCount = 4,
+            progress = 0.6f
+        )
+    }
+}
+
+@Preview
+@Composable
+fun ProgressBarPreview() {
+    ZubZubTheme {
+        ProgressBar(
+            progress = 0.75f,
+            modifier = Modifier.padding(16.dp)
         )
     }
 } 

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/ProgressBar.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/ProgressBar.kt
@@ -1,0 +1,41 @@
+package com.cyberwarriers.zubzub.feature.group_cart.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * 진행률 바 컴포넌트
+ */
+@Composable
+fun ProgressBar(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor = Color(0xFFE0E0E0)
+    val progressColor = Color(0xFF4CAF50)
+
+    Box(
+        modifier = modifier
+            .height(12.dp)
+            .fillMaxWidth()
+            .background(
+                color = backgroundColor,
+            )
+    ) {
+        // 진행률 표시
+        Box(
+            modifier = Modifier
+                .height(12.dp)
+                .fillMaxWidth(progress.coerceIn(0f, 1f))
+                .background(
+                    color = progressColor,
+                )
+        )
+    }
+}

--- a/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/ProgressBar.kt
+++ b/feature/group-cart/src/main/java/com/cyberwarriers/zubzub/feature/group_cart/presentation/ui/components/ProgressBar.kt
@@ -1,41 +1,66 @@
 package com.cyberwarriers.zubzub.feature.group_cart.presentation.ui.components
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.cyberwarriers.zubzub.core.ui.theme.ZubZubTheme
 
 /**
- * 진행률 바 컴포넌트
+ * 애니메이션이 적용된 진행률 바 컴포넌트
  */
 @Composable
 fun ProgressBar(
     progress: Float,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
-    val backgroundColor = Color(0xFFE0E0E0)
-    val progressColor = Color(0xFF4CAF50)
-
+    val backgroundColor = Color(0xFFE0E0E0) // 연한 회색
+    val progressColor = Color(0xFF4CAF50) // 녹색
+    
+    // 애니메이션 적용된 진행률
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress.coerceIn(0f, 1f),
+        label = "progress_animation"
+    )
+    
     Box(
         modifier = modifier
             .height(12.dp)
             .fillMaxWidth()
             .background(
                 color = backgroundColor,
+                shape = RoundedCornerShape(6.dp)
             )
     ) {
         // 진행률 표시
         Box(
             modifier = Modifier
                 .height(12.dp)
-                .fillMaxWidth(progress.coerceIn(0f, 1f))
+                .fillMaxWidth(animatedProgress)
                 .background(
                     color = progressColor,
+                    shape = RoundedCornerShape(6.dp)
                 )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun ProgressBarPreview() {
+    ZubZubTheme {
+        ProgressBar(
+            progress = 0.75f,
+            modifier = Modifier.padding(16.dp)
         )
     }
 }


### PR DESCRIPTION
## 주요 변경사항

### 1. 진행률 계산 로직 구현
- **파일**: `GroupCartDataSource.kt`
- 아이템 상태 변경 시 자동으로 진행률 계산
- 공식: `(완료된 아이템 수 / 전체 아이템 수) * 100`
- `updateCartItemStatus()`, `addCartItem()`, `removeCartItem()` 메서드에 진행률 업데이트 로직 추가

### 2. Firebase 데이터 모델 업데이트
- **파일**: `CartGroupFirebaseEntity.kt`
- `progressPercentage: Int = 0` 필드 추가
- Firebase `cart_groups` 컬렉션에 진행률 저장

### 3. Repository 인터페이스 확장
- **파일**: `CartGroupRepository.kt`
- `updateGroupProgress()` 메서드 추가
- 데이터 레이어에서 진행률 업데이트 지원

